### PR TITLE
Fix filtering of non-string values

### DIFF
--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -15349,7 +15349,7 @@
 									type = column.definition.headerFilterFunc;
 									filterFunc = function(data){
 										var params = column.definition.headerFilterFuncParams || {};
-										var fieldVal = column.getFieldValue(data);
+										var fieldVal = String(column.getFieldValue(data));
 
 										params = typeof params === "function" ? params(value, fieldVal, data) : params;
 
@@ -15363,7 +15363,7 @@
 							case "function":
 								filterFunc = function(data){
 									var params = column.definition.headerFilterFuncParams || {};
-									var fieldVal = column.getFieldValue(data);
+									var fieldVal = String(column.getFieldValue(data));
 
 									params = typeof params === "function" ? params(value, fieldVal, data) : params;
 


### PR DESCRIPTION
The unique column values are stored as keys of the output array of the  _uniqueColumnValues method. When they are used for filtering it has to be ensured that they are compared to strings in order to avoid false negatives.